### PR TITLE
updated verions for vulnerability fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>2.1.12.RELEASE</version>
+        <version>2.3.5.RELEASE</version>
         <relativePath />
         <!-- lookup parent from repository -->
     </parent>
@@ -29,7 +29,7 @@
 
     <properties>
         <argLine>-Djava.security.egd=file:/dev/./urandom</argLine>
-        <commons-io.version>2.6</commons-io.version>
+        <commons-io.version>2.7</commons-io.version>
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
         <docker.directory>docker-ready</docker.directory>
         <docker.registry>ibmcom</docker.registry>
@@ -39,9 +39,10 @@
         <helm.repo.api.url>${helm.repo.addr}/api/accanto</helm.repo.api.url>
         <helm.repo.snapshots.url>${helm.repo.addr}/accanto/snapshots</helm.repo.snapshots.url>
         <helm.repo.url>${helm.repo.addr}/accanto/stable</helm.repo.url>
+        <jackson.version>2.12.4</jackson.version>
         <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
         <java.version>1.8</java.version>
-        <kafka.version>2.2.1</kafka.version>
+        <kafka.version>3.0.0</kafka.version>
         <kiwigrid.version>2.5</kiwigrid.version>
         <logstash-logback-encoder.version>5.1</logstash-logback-encoder.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
@@ -52,19 +53,23 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <scala.version>2.12</scala.version>
-        <sortpom-maven-plugin.version>2.8.0</sortpom-maven-plugin.version>
-        <springfox.version>2.8.0</springfox.version>
-        <wiremock.version>2.1.3.RELEASE</wiremock.version>
-        <tomcat.version>9.0.43</tomcat.version>
-        <jackson.version>2.12.4</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>
+        <sortpom-maven-plugin.version>2.8.0</sortpom-maven-plugin.version>
         <spring-security.version>5.3.8.RELEASE</spring-security.version>
+        <springfox.version>3.0.0</springfox.version>
+        <tomcat.version>9.0.54</tomcat.version>
+        <wiremock.version>2.1.3.RELEASE</wiremock.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.0-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/test/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/PackageManagementControllerTest.java
+++ b/src/test/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/PackageManagementControllerTest.java
@@ -229,7 +229,7 @@ public class PackageManagementControllerTest {
         httpEntity = new HttpEntity<>(headers);
         responseEntity = testRestTemplate.withBasicAuth("user", "password")
                                          .exchange(PACKAGE_MANAGEMENT_VNFD_ENDPOINT, HttpMethod.GET, httpEntity, Resource.class, vnfPkgId);
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 
         // Check when Accept type of text/plain but multiple vnfds found within the package
         when(packageManagementService.getVnfdAsYaml(eq(vnfPkgId))).thenThrow(new UnexpectedPackageContentsException("Unexpected package contents"));
@@ -237,7 +237,7 @@ public class PackageManagementControllerTest {
         httpEntity = new HttpEntity<>(headers);
         responseEntity = testRestTemplate.withBasicAuth("user", "password")
                                          .exchange(PACKAGE_MANAGEMENT_VNFD_ENDPOINT, HttpMethod.GET, httpEntity, String.class, vnfPkgId);
-        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @Test


### PR DESCRIPTION
Updated versions to fix following vulnerabilities:

1. CVE-2021-33037
2. CVE-2021-30640
3. CVE-2021-41079
4. CVE-2021-42340​
5. CVE-2021-29425
6. CVE-2020-9488
7. PRISMA-2021-0055
8. CVE-2019-17495​
9. CVE-2020-8908
10. CVE-2018-10237
11. CVE-2020-13956