### PR TITLE
Build new image for release 0.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <!-- Must be duplicated for versions:set plugin to work in builds -->
     <groupId>com.accantosystems.stratoss</groupId>
     <artifactId>sol003-lifecycle-driver</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <packaging>jar</packaging>
 
     <name>SOL003 VNFM Driver</name>


### PR DESCRIPTION
- **Description of the changes**: Build new image for release 0.2.5
The newly built image should show a VERSION_ID="11"

```
docker run -it sol003-lifecycle-driver:0.2.5 /bin/bash -c "cat /etc/*release"

PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```
