### PR TITLE
changes docker hub's ibmcom to icr.io/ibm/cp4na-drivers in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <commons-io.version>2.7</commons-io.version>
         <docker-maven-plugin.version>1.0.0</docker-maven-plugin.version>
         <docker.directory>docker-ready</docker.directory>
-        <docker.registry>ibmcom</docker.registry>
+        <docker.registry>icr.io/ibm/cp4na-drivers</docker.registry>
         <guava.version>30.0-jre</guava.version>
         <helm.chart.name>${project.artifactId}</helm.chart.name>
         <helm.download.url>https://get.helm.sh/${helm-client-executable}</helm.download.url>


### PR DESCRIPTION
As per new process, we are pushing all images to icr.io instead of docker hub.