### PR TITLE
Use Keystore password from the secret cp4na-o-keystore

### DIFF
--- a/src/main/resources/docker/commands.sh
+++ b/src/main/resources/docker/commands.sh
@@ -16,5 +16,5 @@ CERTKEY=$CERTDIR/tls.key
 CERT=$CERTDIR/tls.crt
 
 cd ${alm_vnfmdriver_directory}
-openssl pkcs12 -export -inkey $CERTKEY -in $CERT -out $KEYSTORE -password pass:password -name "sol003-lifecycle-driver"
+[ ! -f $KEYSTORE ] && openssl pkcs12 -export -inkey $CERTKEY -in $CERT -out $KEYSTORE -password pass:"${SERVER_SSL_KEY_STORE_PASSWORD}" -name "sol003-lifecycle-driver"
 java $TS_OPTION $JVM_OPTIONS -jar /data/sol003-lifecycle-driver-@project.version@.jar

--- a/src/main/resources/helm/sol003-lifecycle-driver/templates/sol003-lifecycle-driver.yaml
+++ b/src/main/resources/helm/sol003-lifecycle-driver/templates/sol003-lifecycle-driver.yaml
@@ -119,6 +119,12 @@ spec:
               name: sol003-lifecycle-driver
           resources:
 {{ toYaml .Values.app.resources | indent 12 }}
+          env:
+          - name: SERVER_SSL_KEY_STORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.global.security.certificates.keystore.secretName }}
+                key: keystorePassword
           volumeMounts:
 {{- if .Values.app.certificateSecret }}
           - mountPath: /var/lm/certs

--- a/src/main/resources/helm/sol003-lifecycle-driver/values.yaml
+++ b/src/main/resources/helm/sol003-lifecycle-driver/values.yaml
@@ -26,7 +26,7 @@ global:
     enabled: false
     certificates:
       keystore:
-        secretName: lm-keystore
+        secretName: cp4na-o-keystore
 
 ## Docker
 docker:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,5 +35,5 @@ server:
     key-store-type: PKCS12
     key-store: /var/lm/keystore/keystore.p12
     key-store-password: password
-    key-alias: restconf-driver
+    key-alias: sol003-lifecycle-driver
     enabled: false


### PR DESCRIPTION
#92 
Keystore password used in enabling ssl needs to be obtained from the secret cp4na-o-keystore.
Signed-off-by: Haynes Davis <haynes.davis@ibm.com>