### PR TITLE
API major version change as per spec 3.5.1

### DIFF
--- a/src/main/java/com/accantosystems/stratoss/vnfmdriver/driver/VNFLifecycleManagementDriver.java
+++ b/src/main/java/com/accantosystems/stratoss/vnfmdriver/driver/VNFLifecycleManagementDriver.java
@@ -27,7 +27,7 @@ import com.accantosystems.stratoss.vnfmdriver.service.AuthenticatedRestTemplateS
  * Endpoints expected to be found under the following structure
  *
  * <ul>
- *     <li>{apiRoot}/vnflcm/v1
+ *     <li>{apiRoot}/vnflcm/v2
  *     <li><ul>
  *         <li>/vnf_instances</li>
  *         <li><ul>
@@ -70,7 +70,7 @@ public class VNFLifecycleManagementDriver {
 
     private final static Logger logger = LoggerFactory.getLogger(VNFLifecycleManagementDriver.class);
 
-    private final static String API_CONTEXT_ROOT = "/vnflcm/v1";
+    private final static String API_CONTEXT_ROOT = "/vnflcm/v2";
     private final static String API_PREFIX_VNF_INSTANCES = "/vnf_instances";
     private final static String API_PREFIX_OP_OCCURRENCES = "/vnf_lcm_op_occs";
     private final static String API_PREFIX_SUBSCRIPTIONS = "/subscriptions";

--- a/src/main/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/LifecycleNotificationController.java
+++ b/src/main/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/LifecycleNotificationController.java
@@ -23,7 +23,7 @@ import com.accantosystems.stratoss.vnfmdriver.service.ExternalMessagingService;
 import io.swagger.annotations.ApiOperation;
 
 @RestController("LifecycleNotificationController")
-@RequestMapping("/vnflcm/v1/notifications")
+@RequestMapping("/vnflcm/v2/notifications")
 public class LifecycleNotificationController {
 
     private final static Logger logger = LoggerFactory.getLogger(LifecycleNotificationController.class);

--- a/src/test/java/com/accantosystems/stratoss/vnfmdriver/driver/VNFLifecycleManagementDriverTest.java
+++ b/src/test/java/com/accantosystems/stratoss/vnfmdriver/driver/VNFLifecycleManagementDriverTest.java
@@ -34,7 +34,7 @@ import com.accantosystems.stratoss.vnfmdriver.service.AuthenticatedRestTemplateS
 @AutoConfigureWireMock(port = 0)
 public class VNFLifecycleManagementDriverTest {
 
-    private static final String BASE_API_ROOT = "/vnflcm/v1";
+    private static final String BASE_API_ROOT = "/vnflcm/v2";
     private static final String VNF_INSTANCE_ENDPOINT = BASE_API_ROOT + "/vnf_instances";
     private static final String LCM_OP_OCC_ENDPOINT = BASE_API_ROOT + "/vnf_lcm_op_occs";
     private static final String SUBSCRIPTIONS_ENDPOINT = BASE_API_ROOT + "/subscriptions";

--- a/src/test/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/LifecycleNotificationControllerTest.java
+++ b/src/test/java/com/accantosystems/stratoss/vnfmdriver/web/etsi/LifecycleNotificationControllerTest.java
@@ -27,7 +27,7 @@ import com.accantosystems.stratoss.vnfmdriver.service.ExternalMessagingService;
 @ActiveProfiles({ "test" })
 public class LifecycleNotificationControllerTest {
 
-    public static final String NOTIFICATIONS_ENDPOINT = "/vnflcm/v1/notifications";
+    public static final String NOTIFICATIONS_ENDPOINT = "/vnflcm/v2/notifications";
 
     @Autowired private TestRestTemplate testRestTemplate;
     @MockBean private ExternalMessagingService externalMessagingService;


### PR DESCRIPTION
#94
According to sol003 spec version 3.5.1, the API major version should be 2.
Signed-off-by: root <root@api.ranjeet-dev.cp.fyre.ibm.com>