### PR TITLE
attempting to fix- CVE-2019-10172

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.3.6.RELEASE</version>
+            <version>2.5.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
#109
There is no direct fix as jackson-mapper-asl version 1.9.13 is already being used in the code which is already maximum version so we are attempting to fix to upgrade spring-security-oauth2 version. 
Signed-off-by: root <root@api.ranjeet-dev.cp.fyre.ibm.com>