### PR TITLE
updated release document to use prod profile instead of dev profile

### DIFF
--- a/developer_docs/release.md
+++ b/developer_docs/release.md
@@ -74,9 +74,9 @@ Complete steps 1-4 from the main release instructions (found above).
 > You can find the openjdk image details here: https://github.com/IBM/sol003-lifecycle-driver/blob/master/src/main/resources/docker/Dockerfile#L1-L2  
 > `docker pull openjdk:8u302-jre`
 
-Run the following command (the `dev` profile ensures extra log statements are available in the built code):
+Run the following command (the `prod` profile ensures INFO log statements are available in the built code):
 ```
-./mvnw clean package -Pdev,docker,helm
+./mvnw clean package -Pprod,docker,helm
 ```
 
 This should produce 2 artifacts:


### PR DESCRIPTION
# Pull Request Review

## Checklist

- [x] **Issue** : https://github.com/IBM/sol003-lifecycle-driver/issues/158
- [x] **List of related PRs** : N.A.
- [x] **Project builds without any errors** Yes
- [x] **Unit Tests** : All passed
- [x] **Ran manual functional “smoke” test (does product as a whole still work?)** NA
- [x] **User Story meets the acceptance criteria and passes** NA
- [x]  **Description of the changes**:  Updated release.md document to use prod profile during release of the drivers.